### PR TITLE
fix: add missing dependencies for buildfix: add missing dependencies for buildfix: add missing dependencies …

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.263.1",
     "next": "14.0.0",
+    "next-mdx-remote": "^4.4.1",
+    "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-highlight": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0"
   },


### PR DESCRIPTION
Add next-themes, next-mdx-remote, and rehype-highlight dependencies to resolve Vercel deployment build errors. These packages are imported in the codebase but were missing from package.json.…for buildfix: add missing dependencies for buildUpdate package.json

Add next-themes, next-mdx-remote, and rehype-highlight dependencies to resolve Vercel deployment build errors. These packages are imported in the codebase but were missing from package.json.